### PR TITLE
TESTS: Use all.equal() rather than identical() to compare future plans

### DIFF
--- a/tests/testthat/test-codalm_ci.R
+++ b/tests/testthat/test-codalm_ci.R
@@ -18,7 +18,7 @@ test_that("bootstrap CI works with sequential evaluation", {
     expect_true(mean(B_ci_U >= 0) == 1)
     expect_true(all.equal(dim(B_ci_U), c(2,3)))
     expect_true(mean(B_ci_U >= B_est) == 1)
-    expect_true(identical(plan("list"), oplan))
+    expect_true(all.equal(plan("list"), oplan))
 })
 test_that("bootstrap CI works with multisession evaluation", {
     require(gtools)
@@ -41,5 +41,5 @@ test_that("bootstrap CI works with multisession evaluation", {
     expect_true(mean(B_ci_U >= 0) == 1)
     expect_true(all.equal(dim(B_ci_U), c(2,3)))
     expect_true(mean(B_ci_U >= B_est) == 1)
-    expect_true(identical(plan("list"), oplan))
+    expect_true(all.equal(plan("list"), oplan))
 })

--- a/tests/testthat/test-independence_test.R
+++ b/tests/testthat/test-independence_test.R
@@ -7,7 +7,7 @@ test_that("independence test works with sequential evaluation", {
     oplan <- plan("list")
     p <- codalm_indep_test(y, x)
     expect_true(p > .05)
-    expect_true(identical(plan("list"), oplan))
+    expect_true(all.equal(plan("list"), oplan))
 })
 test_that("independence test works with multisession evaluation", {
     require(gtools)
@@ -17,6 +17,6 @@ test_that("independence test works with multisession evaluation", {
     y <- rdirichlet(100, rep(1,3))
     oplan <- plan("list")
     p <- codalm_indep_test(y, x, parallel = TRUE, strategy = 'multisession', ncpus = 2)
-    expect_true(identical(plan("list"), oplan))
+    expect_true(all.equal(plan("list"), oplan))
 })
 


### PR DESCRIPTION
TESTS: Use all.equal() rather than identical() to compare future plans - the latter will fail with next release of the 'future' package